### PR TITLE
Update ChatHub.cs

### DIFF
--- a/signalr/hubs/samples/6.x/SignalRHubsSample/Snippets/Hubs/ChatHub.cs
+++ b/signalr/hubs/samples/6.x/SignalRHubsSample/Snippets/Hubs/ChatHub.cs
@@ -15,7 +15,6 @@ public class ChatHub : Hub
     // <snippet_OnDisconnectedAsync>
     public override async Task OnDisconnectedAsync(Exception? exception)
     {
-        await Groups.RemoveFromGroupAsync(Context.ConnectionId, "SignalR Users");
         await base.OnDisconnectedAsync(exception);
     }
     // </snippet_OnDisconnectedAsync>


### PR DESCRIPTION
Contributes to dotnet/AspNetCore.Docs  PR #26394
Removed all RemoveFromGroupAsync calls from within OnDisconnectedAsync.  There was only one.