### PR TITLE
Add sample for Minimal API argument lists

### DIFF
--- a/fundamentals/minimal-apis/samples/arg-lists/Program.cs
+++ b/fundamentals/minimal-apis/samples/arg-lists/Program.cs
@@ -1,0 +1,91 @@
+using Microsoft.EntityFrameworkCore;
+
+var builder = WebApplication.CreateBuilder(args);
+builder.Services.AddDatabaseDeveloperPageExceptionFilter();
+builder.Services.AddDbContext<TodoDb>(opt => opt.UseInMemoryDatabase("TodoList"));
+var app = builder.Build();
+
+app.MapGet("/todoitems", async (TodoDb db) =>
+    await db.Todos.Select(x => new TodoItemDTO(x)).ToListAsync());
+
+app.MapGet("/todoitems/{id}", async ([AsParameters] TodoItemRequest request) =>
+    await request.Db.Todos.FindAsync(request.Id)
+        is Todo todo
+            ? Results.Ok(new TodoItemDTO(todo))
+            : Results.NotFound());
+
+app.MapPost("/todoitems", async ([AsParameters] CreateTodoItemRequest request) =>
+{
+    var todoItem = new Todo
+    {
+        IsComplete = request.Dto.IsComplete,
+        Name = request.Dto.Name
+    };
+
+    request.Db.Todos.Add(todoItem);
+    await request.Db.SaveChangesAsync();
+
+    return Results.Created($"/todoitems/{todoItem.Id}", new TodoItemDTO(todoItem));
+});
+
+app.MapPut("/todoitems/{id}", async ([AsParameters] EditTodoItemRequest request) =>
+{
+    var todo = await request.Db.Todos.FindAsync(request.Id);
+
+    if (todo is null) return Results.NotFound();
+
+    todo.Name = request.Dto.Name;
+    todo.IsComplete = request.Dto.IsComplete;
+
+    await request.Db.SaveChangesAsync();
+
+    return Results.NoContent();
+});
+
+app.MapDelete("/todoitems/{id}", async ([AsParameters] TodoItemRequest request) =>
+{
+    if (await request.Db.Todos.FindAsync(request.Id) is Todo todo)
+    {
+        request.Db.Todos.Remove(todo);
+        await request.Db.SaveChangesAsync();
+        return Results.Ok(new TodoItemDTO(todo));
+    }
+
+    return Results.NotFound();
+});
+
+app.Run();
+
+public class Todo
+{
+    public int Id { get; set; }
+    public string? Name { get; set; }
+    public bool IsComplete { get; set; }
+    public string? Secret { get; set; }
+}
+
+public class TodoItemDTO
+{
+    public int Id { get; set; }
+    public string? Name { get; set; }
+    public bool IsComplete { get; set; }
+
+    public TodoItemDTO() { }
+    public TodoItemDTO(Todo todoItem) =>
+    (Id, Name, IsComplete) = (todoItem.Id, todoItem.Name, todoItem.IsComplete);
+}
+
+
+class TodoDb : DbContext
+{
+    public TodoDb(DbContextOptions<TodoDb> options)
+        : base(options) { }
+
+    public DbSet<Todo> Todos => Set<Todo>();
+}
+
+record TodoItemRequest(int Id, TodoDb Db);
+
+record CreateTodoItemRequest(TodoItemDTO Dto, TodoDb Db);
+
+record EditTodoItemRequest(int Id, TodoItemDTO Dto, TodoDb Db);

--- a/fundamentals/minimal-apis/samples/arg-lists/TodoApi.csproj
+++ b/fundamentals/minimal-apis/samples/arg-lists/TodoApi.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <TargetFramework>net7.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="7.0.0-preview.7.22376.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.0-preview.7.22376.2" />
+  </ItemGroup>
+</Project>

--- a/fundamentals/minimal-apis/samples/arg-lists/appsettings.Development.json
+++ b/fundamentals/minimal-apis/samples/arg-lists/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/fundamentals/minimal-apis/samples/arg-lists/appsettings.json
+++ b/fundamentals/minimal-apis/samples/arg-lists/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
Add code sample for dotnet/AspNetCore.Docs#26540 for using `[AsParameters]` with Minimal APIs.

I took the code from [here](https://docs.microsoft.com/en-us/aspnet/core/tutorials/min-web-api?view=aspnetcore-6.0&tabs=visual-studio-code#prevent-over-posting) and then added the three `*TodoItemRequest` types to use with the attribute for the POST, PUT and DELETE endpoints.
