### PR TITLE
Update to .NET 7

### DIFF
--- a/tutorials/scalable-razor-apps/end/Dockerfile
+++ b/tutorials/scalable-razor-apps/end/Dockerfile
@@ -1,11 +1,10 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:7.0 AS base
 WORKDIR /app
 EXPOSE 80
-EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
 WORKDIR /src
 COPY ["ScalableRazor.csproj", "."]
 RUN dotnet restore "./ScalableRazor.csproj"

--- a/tutorials/scalable-razor-apps/start/Dockerfile
+++ b/tutorials/scalable-razor-apps/start/Dockerfile
@@ -3,7 +3,6 @@
 FROM mcr.microsoft.com/dotnet/aspnet:7.0 AS base
 WORKDIR /app
 EXPOSE 80
-EXPOSE 443
 
 FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
 WORKDIR /src


### PR DESCRIPTION
- Update Dockerfile to .NET 7.
- Remove `EXPOSE 443`.

`443` assumes that a cert is specifies (which often won't be) and that `443` is the desired port. It also breaks the container "Browse" experience in VS Code.