### PR TITLE
fix typo in problem-details-service

### DIFF
--- a/fundamentals/middleware/problem-details-service/Program.cs
+++ b/fundamentals/middleware/problem-details-service/Program.cs
@@ -292,9 +292,9 @@ else
                 if (exceptionType != null &&
                    exceptionType.Message.Contains("infinity"))
                 {
-                    title = "Arguement exception";
+                    title = "Argument exception";
                     detail = "Invalid input";
-                    type = "https://errors.example.com/arguementException";
+                    type = "https://errors.example.com/argumentException";
                 }
 
                 await problemDetailsService.WriteAsync(new ProblemDetailsContext


### PR DESCRIPTION
While going through the samples in the docs I stumbled across this typo in the example.
Fix the `Arguement` typo to `Argument`.