### PR TITLE
IForm post /2

### DIFF
--- a/fundamentals/minimal-apis/samples/IFormFile/IformPost/IformPost.csproj
+++ b/fundamentals/minimal-apis/samples/IFormFile/IformPost/IformPost.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+</Project>

--- a/fundamentals/minimal-apis/samples/IFormFile/IformPost/Program.cs
+++ b/fundamentals/minimal-apis/samples/IFormFile/IformPost/Program.cs
@@ -1,0 +1,23 @@
+using Microsoft.AspNetCore.Mvc;
+
+var builder = WebApplication.CreateBuilder();
+
+builder.Services.AddAntiforgery();
+
+var app = builder.Build();
+
+//app.UseAntiforgery();
+
+app.MapPost("/upload", ([FromForm] DocumentUpload document) =>
+{
+    return Results.Ok();
+});
+
+app.Run();
+
+public class DocumentUpload
+{
+    public string Name { get; set; } = "Uploaded Document";
+    public string? Description { get; set; }
+    public IFormFile? Document { get; set; }
+}

--- a/fundamentals/minimal-apis/samples/IFormFile/IformPost/appsettings.json
+++ b/fundamentals/minimal-apis/samples/IFormFile/IformPost/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
***EDIT UPDATE***: Looks like I need to use an HTML form like [this approach](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/minimal-apis/parameter-binding?view=aspnetcore-8.0#binding-to-forms-with-iformcollection-iformfile-and-iformfilecollection)

Contributes to https://github.com/dotnet/AspNetCore.Docs/issues/30644

@bruno see [Support for form files in new form binding](https://devblogs.microsoft.com/dotnet/asp-net-core-updates-in-dotnet-8-rc-2/#support-for-form-files-in-new-form-binding#support-for-form-files-in-new-form-binding)

@brunolins16 When I test with postman, I get

```
System.InvalidOperationException: Endpoint HTTP: POST /upload contains anti-forgery 
metadata, but a middleware was not found that supports anti-forgery.
Configure your application startup by adding app.UseAntiforgery() in the application 
startup code. If there are calls to app.UseRouting() and app.UseEndpoints(...), the call to 
app.UseAntiforgery() must go between them. Calls to app.UseAntiforgery() must be 
placed after calls to app.UseAuthentication() and app.UseAuthorization().
```

So when I add `app.UseAntiforgery();`, I get 

```
System.InvalidOperationException: This form is being accessed with an invalid anti-
forgery token. Validate the `IAntiforgeryValidationFeature` on the request before reading 
from the form.
```