### PR TITLE
update RDG samples to be compatible with AOT

### DIFF
--- a/fundamentals/aot/diagnostics/Rdg10/Program.cs
+++ b/fundamentals/aot/diagnostics/Rdg10/Program.cs
@@ -2,9 +2,15 @@
 #if NEVER
 #elif RDG10
 // <snippet_1>
+using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Mvc;
 
-var builder = WebApplication.CreateBuilder(args);
+var builder = WebApplication.CreateSlimBuilder(args);
+builder.Services.ConfigureHttpJsonOptions(options =>
+{
+    options.SerializerOptions.TypeInfoResolverChain.Insert(0,
+                                 AppJsonSerializerContext.Default);
+});
 
 var app = builder.Build();
 
@@ -15,12 +21,23 @@ app.Run();
 
 public record TodoRequest(HttpContext HttpContext, [FromRoute] int Id);
 public record Todo(int Id);
+[JsonSerializable(typeof(Todo[]))]
+internal partial class AppJsonSerializerContext : JsonSerializerContext
+{
+
+}
 // </snippet_1>
 #elif RDG10F
 // <snippet_1f>
+using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Mvc;
 
-var builder = WebApplication.CreateBuilder(args);
+var builder = WebApplication.CreateSlimBuilder(args);
+builder.Services.ConfigureHttpJsonOptions(options =>
+{
+    options.SerializerOptions.TypeInfoResolverChain.Insert(0,
+                                 AppJsonSerializerContext.Default);
+});
 
 var app = builder.Build();
 
@@ -31,6 +48,11 @@ app.Run();
 
 public record TodoRequest(HttpContext HttpContext, [FromRoute] int Id);
 public record Todo(int Id);
+[JsonSerializable(typeof(Todo[]))]
+internal partial class AppJsonSerializerContext : JsonSerializerContext
+{
+
+}
 // </snippet_1f>
 #endif
 

--- a/fundamentals/aot/diagnostics/Rdg10/Rdg10.csproj
+++ b/fundamentals/aot/diagnostics/Rdg10/Rdg10.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <PublishAot>true</PublishAot>
     <InvariantGlobalization>true</InvariantGlobalization>
     <EnableRequestDelegateGenerator>true</EnableRequestDelegateGenerator>
   </PropertyGroup>

--- a/fundamentals/aot/diagnostics/Rdg11/Program.cs
+++ b/fundamentals/aot/diagnostics/Rdg11/Program.cs
@@ -2,7 +2,14 @@
 #if NEVER
 #elif RDG11
 // <snippet_1>
+using System.Text.Json.Serialization;
+
 var builder = WebApplication.CreateSlimBuilder(args);
+builder.Services.ConfigureHttpJsonOptions(options =>
+{
+    options.SerializerOptions.TypeInfoResolverChain.Insert(0,
+                                 AppJsonSerializerContext.Default);
+});
 
 var app = builder.Build();
 app.MapEndpoints<Todo>();
@@ -24,12 +31,28 @@ public static class RouteBuilderExtensions
     }
 }
 
-record Todo();
-record Wrapper<T> { }
+record Wrapper<T>(T Value);
+class Todo
+{
+    public int Id { get; set; }
+    public string Task { get; set; }
+}
+[JsonSerializable(typeof(Wrapper<Todo>[]))]
+internal partial class AppJsonSerializerContext : JsonSerializerContext
+{
+
+}
 // </snippet_1>
 #elif RDG11F
 // <snippet_1f>
+using System.Text.Json.Serialization;
+
 var builder = WebApplication.CreateSlimBuilder(args);
+builder.Services.ConfigureHttpJsonOptions(options =>
+{
+    options.SerializerOptions.TypeInfoResolverChain.Insert(0,
+                                 AppJsonSerializerContext.Default);
+});
 
 var app = builder.Build();
 app.MapTodoEndpoints();
@@ -40,18 +63,23 @@ public static class TodoRouteBuilderExtensions
     public static IEndpointRouteBuilder MapTodoEndpoints(this IEndpointRouteBuilder app)
     {
         app.MapPost("/input", (Todo value) => value);
-        app.MapGet("/result", () => new Todo());
+        app.MapGet("/result", () => new Todo(1, "Walk the dog"));
         app.MapPost("/input-with-wrapper", (Wrapper<Todo> value) => value);
         app.MapGet("/async", async () =>
         {
             await Task.CompletedTask;
-            return new Todo();
+            return new Todo(1, "Walk the dog");
         });
         return app;
     }
 }
 
-record Todo();
-record Wrapper<T> { }
+record Wrapper<T>(T Value);
+record Todo(int Id, string Task);
+[JsonSerializable(typeof(Wrapper<Todo>[]))]
+internal partial class AppJsonSerializerContext : JsonSerializerContext
+{
+
+}
 // </snippet_1f>
 #endif

--- a/fundamentals/aot/diagnostics/Rdg11/Rdg11.csproj
+++ b/fundamentals/aot/diagnostics/Rdg11/Rdg11.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+	  <PublishAot>true</PublishAot>
     <EnableRequestDelegateGenerator>true</EnableRequestDelegateGenerator>
     <LangVersion>preview</LangVersion>
   </PropertyGroup>

--- a/fundamentals/aot/diagnostics/Rdg12/Program.cs
+++ b/fundamentals/aot/diagnostics/Rdg12/Program.cs
@@ -2,7 +2,14 @@
 #if NEVER
 #elif RDG12
 // <snippet_1>
-var builder = WebApplication.CreateBuilder(args);
+using System.Text.Json.Serialization;
+
+var builder = WebApplication.CreateSlimBuilder(args);
+builder.Services.ConfigureHttpJsonOptions(options =>
+{
+    options.SerializerOptions.TypeInfoResolverChain.Insert(0,
+                                 AppJsonSerializerContext.Default);
+});
 
 var app = builder.Build();
 app.MapEndpoints();
@@ -13,24 +20,37 @@ public static class TodoRouteBuilderExtensions
     public static IEndpointRouteBuilder MapEndpoints(this IEndpointRouteBuilder app)
     {
         app.MapPost("/input", (Todo value) => value);
-        app.MapGet("/result", () => new Todo());
+        app.MapGet("/result", () => new Todo(1, "Walk the dog"));
         app.MapPost("/input-with-wrapper", (Wrapper<Todo> value) => value);
         app.MapGet("/async", async () =>
         {
             await Task.CompletedTask;
-            return new Todo();
+            return new Todo(1, "Walk the dog");
         });
         return app;
     }
 
-    private record Todo { };
+    private record Todo(int Id, string Task);
 }
 
-record Wrapper<T> { }
+record Wrapper<T>(T Value);
+[JsonSerializable(typeof(Wrapper<TodoRouteBuilderExtensions.Todo>[]))]
+internal partial class AppJsonSerializerContext : JsonSerializerContext
+{
+
+}
 // </snippet_1>
 #elif RDG12F
 // <snippet_1f>
-var builder = WebApplication.CreateBuilder(args);
+using System.Text.Json.Serialization;
+
+var builder = WebApplication.CreateSlimBuilder(args);
+builder.Services.ConfigureHttpJsonOptions(options =>
+{
+    options.SerializerOptions.TypeInfoResolverChain.Insert(0,
+                                 AppJsonSerializerContext.Default);
+});
+
 
 var app = builder.Build();
 app.MapEndpoints();
@@ -41,19 +61,24 @@ public static class TodoRouteBuilderExtensions
     public static IEndpointRouteBuilder MapEndpoints(this IEndpointRouteBuilder app)
     {
         app.MapPost("/input", (Todo value) => value);
-        app.MapGet("/result", () => new Todo());
+        app.MapGet("/result", () => new Todo(1, "Walk the dog"));
         app.MapPost("/input-with-wrapper", (Wrapper<Todo> value) => value);
         app.MapGet("/async", async () =>
         {
             await Task.CompletedTask;
-            return new Todo();
+            return new Todo(1, "Walk the dog");
         });
         return app;
     }
 
-    public record Todo { };
+    public record Todo(int Id, string Task);
 }
 
-record Wrapper<T> { }
+record Wrapper<T>(T Value);
+[JsonSerializable(typeof(Wrapper<TodoRouteBuilderExtensions.Todo>[]))]
+internal partial class AppJsonSerializerContext : JsonSerializerContext
+{
+
+}
 // </snippet_1f>
 #endif

--- a/fundamentals/aot/diagnostics/Rdg12/Rdg12.csproj
+++ b/fundamentals/aot/diagnostics/Rdg12/Rdg12.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <PublishAot>true</PublishAot>
     <EnableRequestDelegateGenerator>true</EnableRequestDelegateGenerator>
     <LangVersion>preview</LangVersion>
   </PropertyGroup>

--- a/fundamentals/aot/diagnostics/Rdg13/Program.cs
+++ b/fundamentals/aot/diagnostics/Rdg13/Program.cs
@@ -2,11 +2,17 @@
 #if NEVER
 #elif RDG13
 // <snippet_1>
+using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Mvc;
 
-var builder = WebApplication.CreateBuilder(args);
-
+var builder = WebApplication.CreateSlimBuilder(args);
+builder.Services.ConfigureHttpJsonOptions(options =>
+{
+    options.SerializerOptions.TypeInfoResolverChain.Insert(0,
+                                 AppJsonSerializerContext.Default);
+});
 builder.Services.AddKeyedSingleton<IService, FizzService>("fizz");
+
 var app = builder.Build();
 
 app.MapGet("/fizz", ([FromKeyedServices("fizz")][FromServices] IService service) =>
@@ -28,11 +34,22 @@ public class FizzService : IService
         return "Fizz";
     }
 }
+[JsonSerializable(typeof(string[]))]
+internal partial class AppJsonSerializerContext : JsonSerializerContext
+{
+
+}
 #elif RDG13F
 // <snippet_1f>
+using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Mvc;
 
-var builder = WebApplication.CreateBuilder(args);
+var builder = WebApplication.CreateSlimBuilder(args);
+builder.Services.ConfigureHttpJsonOptions(options =>
+{
+    options.SerializerOptions.TypeInfoResolverChain.Insert(0,
+                                 AppJsonSerializerContext.Default);
+});
 
 builder.Services.AddKeyedSingleton<IService, FizzService>("fizz");
 builder.Services.AddKeyedSingleton<IService, BuzzService>("buzz");
@@ -77,6 +94,11 @@ public class FizzBuzzService : IService
     {
         return "FizzBuzz";
     }
+}
+[JsonSerializable(typeof(string[]))]
+internal partial class AppJsonSerializerContext : JsonSerializerContext
+{
+
 }
 // </snippet_1f>
 #endif

--- a/fundamentals/aot/diagnostics/Rdg13/Rdg13.csproj
+++ b/fundamentals/aot/diagnostics/Rdg13/Rdg13.csproj
@@ -5,6 +5,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <InvariantGlobalization>true</InvariantGlobalization>
+    <PublishAot>true</PublishAot>
     <EnableRequestDelegateGenerator>true</EnableRequestDelegateGenerator>
   </PropertyGroup>
 

--- a/fundamentals/aot/diagnostics/Rdg2/Rdg2.csproj
+++ b/fundamentals/aot/diagnostics/Rdg2/Rdg2.csproj
@@ -4,8 +4,8 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+	  <PublishAot>true</PublishAot>
     <EnableRequestDelegateGenerator>true</EnableRequestDelegateGenerator>
-
   </PropertyGroup>
 
 </Project>

--- a/fundamentals/aot/diagnostics/Rdg4/Rdg4.csproj
+++ b/fundamentals/aot/diagnostics/Rdg4/Rdg4.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+	  <PublishAot>true</PublishAot>
     <EnableRequestDelegateGenerator>true</EnableRequestDelegateGenerator>
   </PropertyGroup>
 

--- a/fundamentals/aot/diagnostics/Rdg5/Rdg5.csproj
+++ b/fundamentals/aot/diagnostics/Rdg5/Rdg5.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+	  <PublishAot>true</PublishAot>
     <EnableRequestDelegateGenerator>true</EnableRequestDelegateGenerator>
   </PropertyGroup>
 

--- a/fundamentals/aot/diagnostics/Rdg6/Rdg6.csproj
+++ b/fundamentals/aot/diagnostics/Rdg6/Rdg6.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+	  <PublishAot>true</PublishAot>
     <EnableRequestDelegateGenerator>true</EnableRequestDelegateGenerator>
     <LangVersion>preview</LangVersion>
   </PropertyGroup>

--- a/fundamentals/aot/diagnostics/Rdg7/Rdg7.csproj
+++ b/fundamentals/aot/diagnostics/Rdg7/Rdg7.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+	  <PublishAot>true</PublishAot>
     <EnableRequestDelegateGenerator>true</EnableRequestDelegateGenerator>
     <LangVersion>preview</LangVersion>
   </PropertyGroup>

--- a/fundamentals/aot/diagnostics/Rdg9/Program.cs
+++ b/fundamentals/aot/diagnostics/Rdg9/Program.cs
@@ -20,7 +20,7 @@ var app = builder.Build();
 
 app.MapGet("/v1/todos/{id}", ([AsParameters] TodoItemRequest request) =>
 {
-    return request.todos.ToList().Find(todoItem => todoItem.Id == request.Id) is Todo todo
+    return request.Todos.ToList().Find(todoItem => todoItem.Id == request.Id) is Todo todo
     ? Results.Ok(todo)
     : Results.NotFound();
 });
@@ -31,7 +31,7 @@ struct TodoItemRequest
 {
     public int Id { get; set; }
     //[AsParameters]
-    public Todo[] todos { get; set; }
+    public Todo[] Todos { get; set; }
 }
 
 internal record Todo(int Id, string Task, DateTime DueDate);
@@ -63,7 +63,7 @@ var app = builder.Build();
 
 app.MapGet("/v1/todos/{id}", ([AsParameters] TodoItemRequest request) =>
 {
-     return request.todos.ToList().Find(todoItem => todoItem.Id == request.Id) is Todo todo
+     return request.Todos.ToList().Find(todoItem => todoItem.Id == request.Id) is Todo todo
     ? Results.Ok(todo)
     : Results.NotFound();
 });
@@ -74,7 +74,7 @@ struct TodoItemRequest
 {
     public int Id { get; set; }
     [AsParameters]
-    public Todo[] todos { get; set; }
+    public Todo[] Todos { get; set; }
 }
 
 internal record Todo(int Id, string Task, DateTime DueDate);


### PR DESCRIPTION
I forgot about this issue, but I updated all examples to be compatible with AOT.

> Remove unnecessary code from RDG samples.
> And more can likely be removed from many of [these samples](https://github.com/dotnet/AspNetCore.Docs.Samples/tree/main/fundamentals/aot/diagnostics)

I decided not to remove the code, but instead add the code in the remaining examples.
The main reason is that this is about native AOT, and some of the examples were shorter but didn't compile with AOT enabled. I also checked that each example compiles and runs.

Let me know what you think @Rick-Anderson .
If this is the way to go, we also need to update the highlights because of the added lines (I can do that if you want).

If you do prefer to remove the unnecessary code, I'll revert these changes and update the examples to remove the serializer everywhere.

I don't want to put extra work in your bucket, so if you feel like the examples are good feel free to close this PR without any hard feelings 😊.


Closes #201