### PR TITLE
Add closing brace

### DIFF
--- a/test/integration-tests/8.x/IntegrationTestsSample/tests/RazorPagesProject.Tests/IntegrationTests/IndexPageTests.cs
+++ b/test/integration-tests/8.x/IntegrationTestsSample/tests/RazorPagesProject.Tests/IntegrationTests/IndexPageTests.cs
@@ -26,6 +26,7 @@ public class IndexPageTests :
             AllowAutoRedirect = false
         });
     }
+}
 // </snippet1>
 
 // <snippet2>


### PR DESCRIPTION
This pull request includes a small change to the `IndexPageTests` class in the `RazorPagesProject.Tests` integration tests. The change involves closing a class definition that was previously left open.

* [`test/integration-tests/8.x/IntegrationTestsSample/tests/RazorPagesProject.Tests/IntegrationTests/IndexPageTests.cs`](diffhunk://#diff-0b629177793d4b0e362fa28016748418ddae29368ab8f1a78247b7bcebbafd2bR29): Added a closing brace to the `public IndexPageTests` class to properly close the class definition.