### PR TITLE
Refactor rate limiter rejection handling to support asynchronous response writing

### DIFF
--- a/fundamentals/middleware/rate-limit/WebRateLimitAuth/Program.cs
+++ b/fundamentals/middleware/rate-limit/WebRateLimitAuth/Program.cs
@@ -168,7 +168,6 @@ app.Run();
 #elif FIRST
 // <snippet_1>
 // <snippet>
-// Preceding code removed for brevity.
 using System.Globalization;
 using System.Net;
 using System.Threading.RateLimiting;


### PR DESCRIPTION
Closes #260 

I went with the `Async` method because the response [doesn't has a sync `Write` method](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.http.httpresponse?view=aspnetcore-9.0#extension-methods).

The description in the docs doesn't have to be updated because it doesn't address the `OnRejected` method https://learn.microsoft.com/en-us/aspnet/core/performance/rate-limit?view=aspnetcore-9.0#create-chained-limiters.

cc @Rick-Anderson (I tagged you because it's the Samples repo)