### PR TITLE
Fix username retrieval in rate limiter and ensure proper middleware order

### DIFF
--- a/fundamentals/middleware/rate-limit/WebRateLimitAuth/Program.cs
+++ b/fundamentals/middleware/rate-limit/WebRateLimitAuth/Program.cs
@@ -223,7 +223,7 @@ builder.Services.AddRateLimiter(limiterOptions =>
         var username = "anonymous user";
         if (context.User.Identity?.IsAuthenticated is true)
         {
-            username = context.User.ToString()!;
+            username = context.User.Identity.Name;
         }
 
         return RateLimitPartition.GetSlidingWindowLimiter(username,
@@ -277,9 +277,9 @@ app.UseHttpsRedirection();
 app.UseStaticFiles();
 
 app.UseRouting();
-app.UseRateLimiter();
 
 app.UseAuthentication();
+app.UseRateLimiter(); // important to add after UseAuthentication because the limiter uses auth info
 app.UseAuthorization();
 
 app.MapRazorPages().RequireRateLimiting(userPolicyName);
@@ -386,9 +386,9 @@ app.UseHttpsRedirection();
 app.UseStaticFiles();
 
 app.UseRouting();
-app.UseRateLimiter();
 
 app.UseAuthentication();
+app.UseRateLimiter(); // important to add after UseAuthentication because the limiter uses auth info
 app.UseAuthorization();
 
 static string GetUserEndPointMethod(HttpContext context) =>


### PR DESCRIPTION
It's important to add the rate limiting middleware AFTER the authentication middleware.
If the order is not respected, the user's info will not be available while processing the rate limiting.

BEFORE:
![image](https://github.com/user-attachments/assets/e23818f5-f5bf-429f-863b-f64753ff165f)

AFTER:
![image](https://github.com/user-attachments/assets/5ba8bb49-5a44-4dd2-b7b0-a110f0b7eb87)

Closes https://github.com/dotnet/AspNetCore.Docs/issues/34739
