### PR TITLE
Updated integration-tests 10.x to net10.0

### DIFF
--- a/test/integration-tests/10.x/IntegrationTestsSample/src/RazorPagesProject/Program.cs
+++ b/test/integration-tests/10.x/IntegrationTestsSample/src/RazorPagesProject/Program.cs
@@ -89,6 +89,4 @@ using (var scope = app.Services.CreateScope())
 }
 
 app.Run();
-
-public partial class Program { }
 // </snippet_all>

--- a/test/integration-tests/10.x/IntegrationTestsSample/src/RazorPagesProject/RazorPagesProject.csproj
+++ b/test/integration-tests/10.x/IntegrationTestsSample/src/RazorPagesProject/RazorPagesProject.csproj
@@ -1,17 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="9.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="9.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.0">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.*-*" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.*-*" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="10.*-*" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.*-*" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="10.*-*" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.*-*">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/integration-tests/10.x/IntegrationTestsSample/tests/RazorPagesProject.Tests/RazorPagesProject.Tests.csproj
+++ b/test/integration-tests/10.x/IntegrationTestsSample/tests/RazorPagesProject.Tests/RazorPagesProject.Tests.csproj
@@ -1,26 +1,26 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AngleSharp" Version="1.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="9.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="9.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.0">
+    <PackageReference Include="AngleSharp" Version="1.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="10.*-*" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.*-*" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="10.*-*" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.*-*" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.*-*" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.*-*" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.*-*">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="xunit" Version="2.6.6" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
@Rick-Anderson 

From the back of your pull request https://github.com/dotnet/AspNetCore.Docs.Samples/pull/275 to duplicate 9.x into 10.x 

I have made the current changes to the 10.x sample
- Upgraded to use net10.0
- Use of the latest preview Microsoft packages for now
- Upgraded other packages to the latest stable versions
- Removed the unrequired `public partial class Program { }` as per [aspnetcore-10/includes/testAppsTopLevel.md](https://github.com/dotnet/AspNetCore.Docs/blob/main/aspnetcore/release-notes/aspnetcore-10/includes/testAppsTopLevel.md)

These tests have been ran successfully on my machine that has the `10.0.100-preview.3.25156.7` sdk installed

![image](https://github.com/user-attachments/assets/a4b544f6-8a69-448e-b8ff-8617742b6782)

EDIT: @Rick-Anderson 
Fixes https://github.com/dotnet/AspNetCore.Docs/issues/34726
contributes to https://github.com/dotnet/AspNetCore.Docs/issues/34912