### PR TITLE
Add custom policy provider example to authz BWA

### DIFF
--- a/security/authorization/BlazorWebAppAuthorization/Components/Pages/Home.razor
+++ b/security/authorization/BlazorWebAppAuthorization/Components/Pages/Home.razor
@@ -9,13 +9,13 @@
         <h2>Policy-based authorization example</h2>
         <div class="nav-item px-3">
             <NavLink class="nav-link" href="pass-atleast21-policy-with-authorizeview">
-                <span class="bi bi-person-fill-nav-menu" aria-hidden="true"></span> Pass 'AtLeast21' Policy
+                <span class="bi bi-person-fill-nav-menu" aria-hidden="true"></span> Pass 'AtLeast21' policy
             </NavLink>
         </div>
         <h2>Role-based authorization examples</h2>
         <div class="nav-item px-3">
             <NavLink class="nav-link" href="role-checks-with-authorizeview">
-                <span class="bi bi-person-fill-nav-menu" aria-hidden="true"></span> Role Checks with AuthorizeView
+                <span class="bi bi-person-fill-nav-menu" aria-hidden="true"></span> Role checks with AuthorizeView
             </NavLink>
         </div>
         <div class="nav-item px-3">
@@ -77,14 +77,14 @@
         <h2>Policy provider authorization example</h2>
         <div class="nav-item px-3">
             <NavLink class="nav-link" href="pass-minimumage21-policy">
-                <span class="bi bi-person-fill-nav-menu" aria-hidden="true"></span> Pass 'MinimumAge21' Policy
+                <span class="bi bi-person-fill-nav-menu" aria-hidden="true"></span> Pass 'MinimumAge21' policy
             </NavLink>
         </div>
         <AuthorizeView Policy="MinimumAge21" Context="minimumAge21Context">
             <Authorized>
                 <div class="nav-item px-3">
                     <NavLink class="nav-link" href="pass-minimumage21-policy-with-attribute">
-                        <span class="bi bi-person-fill-nav-menu" aria-hidden="true"></span> Pass 'MinimumAge21' Policy (attribute-based)
+                        <span class="bi bi-person-fill-nav-menu" aria-hidden="true"></span> Pass 'MinimumAge21' policy (attribute-based)
                     </NavLink>
                 </div>
             </Authorized>

--- a/security/authorization/BlazorWebAppAuthorization/Components/Pages/Home.razor
+++ b/security/authorization/BlazorWebAppAuthorization/Components/Pages/Home.razor
@@ -80,11 +80,19 @@
                 <span class="bi bi-person-fill-nav-menu" aria-hidden="true"></span> Pass 'MinimumAge21' Policy
             </NavLink>
         </div>
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="pass-minimumage21-policy-with-attribute">
-                <span class="bi bi-person-fill-nav-menu" aria-hidden="true"></span> Pass 'MinimumAge21' Policy (attribute-based)
-            </NavLink>
-        </div>
+        <AuthorizeView Policy="MinimumAge21" Context="minimumAge21Context">
+            <Authorized>
+                <div class="nav-item px-3">
+                    <NavLink class="nav-link" href="pass-minimumage21-policy-with-attribute">
+                        <span class="bi bi-person-fill-nav-menu" aria-hidden="true"></span> Pass 'MinimumAge21' Policy (attribute-based)
+                    </NavLink>
+                </div>
+            </Authorized>
+            <NotAuthorized>
+                <p>You can't see this link to the 'PassMinimumAge21PolicyWithAttribute' component because you don't satisfy the 'MinimumAge21' policy.</p>
+                <p>If you navigate to the page at '/pass-minimumage21-policy-with-attribute' in the browser's address bar, the redirect for unauthorized access loads the app's sign-in page, where you can sign into the app with Leela's credentials to reach the page.</p>
+            </NotAuthorized>
+        </AuthorizeView>
     </Authorized>
     <NotAuthorized>
         <p>Sign into the app with one of the seeded accounts. See the README file for accounts and credentials.</p>

--- a/security/authorization/BlazorWebAppAuthorization/Components/Pages/Home.razor
+++ b/security/authorization/BlazorWebAppAuthorization/Components/Pages/Home.razor
@@ -74,6 +74,17 @@
                 <span class="bi bi-person-fill-nav-menu" aria-hidden="true"></span> Pass 'CustomerServiceMember' and 'HumanResourcesMember' policies with [Authorize] attributes
             </NavLink>
         </div>
+        <h2>Policy provider authorization example</h2>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="pass-minimumage21-policy">
+                <span class="bi bi-person-fill-nav-menu" aria-hidden="true"></span> Pass 'MinimumAge21' Policy
+            </NavLink>
+        </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="pass-minimumage21-policy-with-attribute">
+                <span class="bi bi-person-fill-nav-menu" aria-hidden="true"></span> Pass 'MinimumAge21' Policy (attribute-based)
+            </NavLink>
+        </div>
     </Authorized>
     <NotAuthorized>
         <p>Sign into the app with one of the seeded accounts. See the README file for accounts and credentials.</p>

--- a/security/authorization/BlazorWebAppAuthorization/Components/Pages/Home.razor
+++ b/security/authorization/BlazorWebAppAuthorization/Components/Pages/Home.razor
@@ -2,7 +2,7 @@
 
 <PageTitle>Home</PageTitle>
 
-<h1>Roles Sample App</h1>
+<h1>Authorization Sample App</h1>
 
 <AuthorizeView>
     <Authorized>

--- a/security/authorization/BlazorWebAppAuthorization/Components/Pages/Home.razor
+++ b/security/authorization/BlazorWebAppAuthorization/Components/Pages/Home.razor
@@ -89,8 +89,11 @@
                 </div>
             </Authorized>
             <NotAuthorized>
-                <p>You can't see this link to the 'PassMinimumAge21PolicyWithAttribute' component because you don't satisfy the 'MinimumAge21' policy.</p>
-                <p>If you navigate to the page at '/pass-minimumage21-policy-with-attribute' in the browser's address bar, the redirect for unauthorized access loads the app's sign-in page, where you can sign into the app with Leela's credentials to reach the page.</p>
+                <p>
+                    You can't see this link to the 'PassMinimumAge21PolicyWithAttribute' component because you don't satisfy 
+                    the 'MinimumAge21' policy. If you navigate to the page at '/pass-minimumage21-policy-with-attribute' in 
+                    the browser's address bar, the Access Denied page is loaded.
+                </p>
             </NotAuthorized>
         </AuthorizeView>
     </Authorized>

--- a/security/authorization/BlazorWebAppAuthorization/Components/Pages/PassMinimumAge21Policy.razor
+++ b/security/authorization/BlazorWebAppAuthorization/Components/Pages/PassMinimumAge21Policy.razor
@@ -4,7 +4,7 @@
 
 <p>
     Uses an AuthorizeView component to apply the policy using the policy's name. 
-    This approach is shown for demonstration purposes, and isn't recommended for 
+    This approach is shown for demonstration purposes and isn't recommended for 
     production code.
 </p>
 

--- a/security/authorization/BlazorWebAppAuthorization/Components/Pages/PassMinimumAge21Policy.razor
+++ b/security/authorization/BlazorWebAppAuthorization/Components/Pages/PassMinimumAge21Policy.razor
@@ -4,8 +4,8 @@
 
 <p>
     Uses an AuthorizeView component to apply the policy using the policy's name. 
-    This approach is shown for demonstration purposes, and isn't generally 
-    recommended for production code.
+    This approach is shown for demonstration purposes, and isn't recommended for 
+    production code.
 </p>
 
 <AuthorizeView Policy="MinimumAge21">

--- a/security/authorization/BlazorWebAppAuthorization/Components/Pages/PassMinimumAge21Policy.razor
+++ b/security/authorization/BlazorWebAppAuthorization/Components/Pages/PassMinimumAge21Policy.razor
@@ -1,6 +1,12 @@
 @page "/pass-minimumage21-policy"
 
-<h1>Pass 'MinimumAge21' policy with AuthorizeView</h1>
+<h1>Pass 'MinimumAge21' policy (weakly-typed approach)</h1>
+
+<p>
+    Uses an AuthorizeView component to apply the policy using the policy's name. 
+    This approach is shown for demonstration purposes, and isn't generally 
+    recommended for production code.
+</p>
 
 <AuthorizeView Policy="MinimumAge21">
     <Authorized>

--- a/security/authorization/BlazorWebAppAuthorization/Components/Pages/PassMinimumAge21Policy.razor
+++ b/security/authorization/BlazorWebAppAuthorization/Components/Pages/PassMinimumAge21Policy.razor
@@ -1,0 +1,12 @@
+@page "/pass-minimumage21-policy"
+
+<h1>Pass 'MinimumAge21' policy with AuthorizeView</h1>
+
+<AuthorizeView Policy="MinimumAge21">
+    <Authorized>
+        <p>You satisfy the 'MinimumAge21' policy.</p>
+    </Authorized>
+    <NotAuthorized>
+        <p>You <b>don't</b> satisfy the 'MinimumAge21' policy.</p>
+    </NotAuthorized>
+</AuthorizeView>

--- a/security/authorization/BlazorWebAppAuthorization/Components/Pages/PassMinimumAge21PolicyWithAttribute.razor
+++ b/security/authorization/BlazorWebAppAuthorization/Components/Pages/PassMinimumAge21PolicyWithAttribute.razor
@@ -1,0 +1,7 @@
+@page "/pass-minimumage21-policy-with-attribute"
+@using BlazorWebAppAuthorization.Policies.Attributes
+@attribute [MinimumAgeAuthorize(21)]
+
+<h1>Pass 'MinimumAge21' policy</h1>
+
+<p>You satisfy the 'MinimumAge21' policy.</p>

--- a/security/authorization/BlazorWebAppAuthorization/Components/Pages/PassMinimumAge21PolicyWithAttribute.razor
+++ b/security/authorization/BlazorWebAppAuthorization/Components/Pages/PassMinimumAge21PolicyWithAttribute.razor
@@ -2,6 +2,12 @@
 @using BlazorWebAppAuthorization.Policies.Attributes
 @attribute [MinimumAgeAuthorize(21)]
 
-<h1>Pass 'MinimumAge21' policy</h1>
+<h1>Pass 'MinimumAge21' policy (strongly-typed approach)</h1>
+
+<p>
+    Applies the policy to the Razor component with an [Authorize] attribute.
+    This approach is preferred for production code, as it's strongly-typed
+    and avoids the use of a string to set the policy and minimum age.
+</p>
 
 <p>You satisfy the 'MinimumAge21' policy.</p>

--- a/security/authorization/BlazorWebAppAuthorization/Components/Pages/PassMinimumAge21PolicyWithAttribute.razor
+++ b/security/authorization/BlazorWebAppAuthorization/Components/Pages/PassMinimumAge21PolicyWithAttribute.razor
@@ -5,7 +5,8 @@
 <h1>Pass 'MinimumAge21' policy (strongly-typed approach)</h1>
 
 <p>
-    Applies the policy to the Razor component with an [Authorize] attribute.
+    Applies the policy to the Razor component with a custom 
+    [MinimumAgeAuthorize] attribute (derived from AuthorizeAttribute).
     This approach is preferred for production code, as it's strongly-typed
     and avoids the use of a string to set the policy and minimum age.
 </p>

--- a/security/authorization/BlazorWebAppAuthorization/Policies/Attributes/MinimumAgeAuthorizeAttribute.cs
+++ b/security/authorization/BlazorWebAppAuthorization/Policies/Attributes/MinimumAgeAuthorizeAttribute.cs
@@ -1,0 +1,27 @@
+using Microsoft.AspNetCore.Authorization;
+
+namespace BlazorWebAppAuthorization.Policies.Attributes;
+
+internal class MinimumAgeAuthorizeAttribute : AuthorizeAttribute
+{
+    const string POLICY_PREFIX = "MinimumAge";
+
+    public MinimumAgeAuthorizeAttribute(int age) => Age = age;
+
+    public int Age
+    {
+        get
+        {
+            if (int.TryParse(Policy.AsSpan(POLICY_PREFIX.Length), out var age))
+            {
+                return age;
+            }
+
+            return default;
+        }
+        set
+        {
+            Policy = $"{POLICY_PREFIX}{value}";
+        }
+    }
+}

--- a/security/authorization/BlazorWebAppAuthorization/Policies/Attributes/MinimumAgeAuthorizeAttribute.cs
+++ b/security/authorization/BlazorWebAppAuthorization/Policies/Attributes/MinimumAgeAuthorizeAttribute.cs
@@ -4,7 +4,7 @@ namespace BlazorWebAppAuthorization.Policies.Attributes;
 
 internal class MinimumAgeAuthorizeAttribute : AuthorizeAttribute
 {
-    const string POLICY_PREFIX = "MinimumAge";
+    private const string PolicyPrefix = "MinimumAge";
 
     public MinimumAgeAuthorizeAttribute(int age) => Age = age;
 
@@ -13,9 +13,9 @@ internal class MinimumAgeAuthorizeAttribute : AuthorizeAttribute
         get
         {
             if (!string.IsNullOrEmpty(Policy) &&
-                Policy.StartsWith(POLICY_PREFIX, 
-                    System.StringComparison.OrdinalIgnoreCase) &&
-                int.TryParse(Policy.AsSpan(POLICY_PREFIX.Length), out var age))
+                Policy.StartsWith(PolicyPrefix, 
+                    StringComparison.OrdinalIgnoreCase) &&
+                int.TryParse(Policy.AsSpan(PolicyPrefix.Length), out var age))
             {
                 return age;
             }
@@ -24,7 +24,8 @@ internal class MinimumAgeAuthorizeAttribute : AuthorizeAttribute
         }
         set
         {
-            Policy = $"{POLICY_PREFIX}{value}";
+            ArgumentOutOfRangeException.ThrowIfNegative(value);
+            Policy = $"{PolicyPrefix}{value}";
         }
     }
 }

--- a/security/authorization/BlazorWebAppAuthorization/Policies/Attributes/MinimumAgeAuthorizeAttribute.cs
+++ b/security/authorization/BlazorWebAppAuthorization/Policies/Attributes/MinimumAgeAuthorizeAttribute.cs
@@ -12,7 +12,9 @@ internal class MinimumAgeAuthorizeAttribute : AuthorizeAttribute
     {
         get
         {
-            if (int.TryParse(Policy.AsSpan(POLICY_PREFIX.Length), out var age))
+            if (!string.IsNullOrEmpty(Policy) &&
+                Policy.StartsWith(POLICY_PREFIX, System.StringComparison.OrdinalIgnoreCase) &&
+                int.TryParse(Policy.AsSpan(POLICY_PREFIX.Length), out var age))
             {
                 return age;
             }

--- a/security/authorization/BlazorWebAppAuthorization/Policies/Attributes/MinimumAgeAuthorizeAttribute.cs
+++ b/security/authorization/BlazorWebAppAuthorization/Policies/Attributes/MinimumAgeAuthorizeAttribute.cs
@@ -13,7 +13,8 @@ internal class MinimumAgeAuthorizeAttribute : AuthorizeAttribute
         get
         {
             if (!string.IsNullOrEmpty(Policy) &&
-                Policy.StartsWith(POLICY_PREFIX, System.StringComparison.OrdinalIgnoreCase) &&
+                Policy.StartsWith(POLICY_PREFIX, 
+                    System.StringComparison.OrdinalIgnoreCase) &&
                 int.TryParse(Policy.AsSpan(POLICY_PREFIX.Length), out var age))
             {
                 return age;

--- a/security/authorization/BlazorWebAppAuthorization/Policies/Attributes/MinimumAgeAuthorizeAttribute.cs
+++ b/security/authorization/BlazorWebAppAuthorization/Policies/Attributes/MinimumAgeAuthorizeAttribute.cs
@@ -2,7 +2,7 @@ using Microsoft.AspNetCore.Authorization;
 
 namespace BlazorWebAppAuthorization.Policies.Attributes;
 
-internal class MinimumAgeAuthorizeAttribute : AuthorizeAttribute
+public class MinimumAgeAuthorizeAttribute : AuthorizeAttribute
 {
     private const string PolicyPrefix = "MinimumAge";
 

--- a/security/authorization/BlazorWebAppAuthorization/Policies/Providers/MinimumAgePolicyProvider.cs
+++ b/security/authorization/BlazorWebAppAuthorization/Policies/Providers/MinimumAgePolicyProvider.cs
@@ -8,15 +8,16 @@ namespace BlazorWebAppAuthorization.Policies.Providers;
 internal class MinimumAgePolicyProvider(IOptions<AuthorizationOptions> options) 
     : IAuthorizationPolicyProvider
 {
-    const string POLICY_PREFIX = "MinimumAge";
-    public DefaultAuthorizationPolicyProvider FallbackPolicyProvider { get; } = 
+    private const string PolicyPrefix = "MinimumAge";
+
+    private DefaultAuthorizationPolicyProvider FallbackPolicyProvider { get; } = 
         new(options);
 
     public Task<AuthorizationPolicy?> GetPolicyAsync(string policyName)
     {
         if (policyName.StartsWith(
-                POLICY_PREFIX, StringComparison.OrdinalIgnoreCase) &&
-            int.TryParse(policyName.AsSpan(POLICY_PREFIX.Length), out var age) &&
+                PolicyPrefix, StringComparison.OrdinalIgnoreCase) &&
+            int.TryParse(policyName.AsSpan(PolicyPrefix.Length), out var age) &&
             age >= 0)
         {
             var policy = new AuthorizationPolicyBuilder(

--- a/security/authorization/BlazorWebAppAuthorization/Policies/Providers/MinimumAgePolicyProvider.cs
+++ b/security/authorization/BlazorWebAppAuthorization/Policies/Providers/MinimumAgePolicyProvider.cs
@@ -1,16 +1,16 @@
+using BlazorWebAppAuthorization.Policies.Requirements;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Options;
-using BlazorWebAppAuthorization.Policies.Requirements;
 
 namespace BlazorWebAppAuthorization.Policies.Providers;
 
 internal class MinimumAgePolicyProvider(IOptions<AuthorizationOptions> options) 
     : IAuthorizationPolicyProvider
 {
-    private readonly DefaultAuthorizationPolicyProvider fallbackPolicyProvider = 
-        new(options);
     const string POLICY_PREFIX = "MinimumAge";
+    public DefaultAuthorizationPolicyProvider FallbackPolicyProvider { get; } = 
+        new(options);
 
     public Task<AuthorizationPolicy?> GetPolicyAsync(string policyName)
     {
@@ -26,15 +26,12 @@ internal class MinimumAgePolicyProvider(IOptions<AuthorizationOptions> options)
             return Task.FromResult<AuthorizationPolicy?>(policy.Build());
         }
 
-        return Task.FromResult<AuthorizationPolicy?>(null);
+        return FallbackPolicyProvider.GetPolicyAsync(policyName);
     }
 
-    public Task<AuthorizationPolicy> GetDefaultPolicyAsync() =>
-        Task.FromResult(
-            new AuthorizationPolicyBuilder(
-                IdentityConstants.ApplicationScheme)
-            .RequireAuthenticatedUser().Build());
+    public Task<AuthorizationPolicy> GetDefaultPolicyAsync() => 
+        FallbackPolicyProvider.GetDefaultPolicyAsync();
 
-    public Task<AuthorizationPolicy?> GetFallbackPolicyAsync() =>
-        Task.FromResult<AuthorizationPolicy?>(null);
+    public Task<AuthorizationPolicy?> GetFallbackPolicyAsync() => 
+        FallbackPolicyProvider.GetFallbackPolicyAsync();
 }

--- a/security/authorization/BlazorWebAppAuthorization/Policies/Providers/MinimumAgePolicyProvider.cs
+++ b/security/authorization/BlazorWebAppAuthorization/Policies/Providers/MinimumAgePolicyProvider.cs
@@ -1,0 +1,34 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using BlazorWebAppAuthorization.Policies.Requirements;
+
+namespace BlazorWebAppAuthorization.Policies.Providers;
+
+internal class MinimumAgePolicyProvider : IAuthorizationPolicyProvider
+{
+    const string POLICY_PREFIX = "MinimumAge";
+
+    public Task<AuthorizationPolicy?> GetPolicyAsync(string policyName)
+    {
+        if (policyName.StartsWith(POLICY_PREFIX, StringComparison.OrdinalIgnoreCase) &&
+            int.TryParse(policyName.AsSpan(POLICY_PREFIX.Length), out var age))
+        {
+            var policy = new AuthorizationPolicyBuilder(
+                IdentityConstants.ApplicationScheme);
+            policy.AddRequirements(new MinimumAgeRequirement(age));
+
+            return Task.FromResult<AuthorizationPolicy?>(policy.Build());
+        }
+
+        return Task.FromResult<AuthorizationPolicy?>(null);
+    }
+
+    public Task<AuthorizationPolicy> GetDefaultPolicyAsync() =>
+        Task.FromResult<AuthorizationPolicy>(
+            new AuthorizationPolicyBuilder(
+                IdentityConstants.ApplicationScheme)
+            .RequireAuthenticatedUser().Build());
+
+    public Task<AuthorizationPolicy?> GetFallbackPolicyAsync() =>
+        Task.FromResult<AuthorizationPolicy?>(null);
+}

--- a/security/authorization/BlazorWebAppAuthorization/Policies/Providers/MinimumAgePolicyProvider.cs
+++ b/security/authorization/BlazorWebAppAuthorization/Policies/Providers/MinimumAgePolicyProvider.cs
@@ -6,12 +6,17 @@ namespace BlazorWebAppAuthorization.Policies.Providers;
 
 internal class MinimumAgePolicyProvider : IAuthorizationPolicyProvider
 {
+    private readonly DefaultAuthorizationPolicyProvider _fallbackPolicyProvider;
     const string POLICY_PREFIX = "MinimumAge";
+
+    public MinimumAgePolicyProvider(Microsoft.Extensions.Options.IOptions<AuthorizationOptions> options) =>
+        _fallbackPolicyProvider = new DefaultAuthorizationPolicyProvider(options);
 
     public Task<AuthorizationPolicy?> GetPolicyAsync(string policyName)
     {
         if (policyName.StartsWith(POLICY_PREFIX, StringComparison.OrdinalIgnoreCase) &&
-            int.TryParse(policyName.AsSpan(POLICY_PREFIX.Length), out var age))
+            int.TryParse(policyName.AsSpan(POLICY_PREFIX.Length), out var age) &&
+            age >= 0)
         {
             var policy = new AuthorizationPolicyBuilder(
                 IdentityConstants.ApplicationScheme);

--- a/security/authorization/BlazorWebAppAuthorization/Policies/Providers/MinimumAgePolicyProvider.cs
+++ b/security/authorization/BlazorWebAppAuthorization/Policies/Providers/MinimumAgePolicyProvider.cs
@@ -5,10 +5,10 @@ using BlazorWebAppAuthorization.Policies.Requirements;
 
 namespace BlazorWebAppAuthorization.Policies.Providers;
 
-internal class MinimumAgePolicyProvider(IOptions<AuthorizationOptions> options)
+internal class MinimumAgePolicyProvider(IOptions<AuthorizationOptions> options) 
     : IAuthorizationPolicyProvider
 {
-    private readonly DefaultAuthorizationPolicyProvider fallbackPolicyProvider =
+    private readonly DefaultAuthorizationPolicyProvider fallbackPolicyProvider = 
         new(options);
     const string POLICY_PREFIX = "MinimumAge";
 

--- a/security/authorization/BlazorWebAppAuthorization/Policies/Providers/MinimumAgePolicyProvider.cs
+++ b/security/authorization/BlazorWebAppAuthorization/Policies/Providers/MinimumAgePolicyProvider.cs
@@ -5,17 +5,17 @@ using BlazorWebAppAuthorization.Policies.Requirements;
 
 namespace BlazorWebAppAuthorization.Policies.Providers;
 
-internal class MinimumAgePolicyProvider : IAuthorizationPolicyProvider
+internal class MinimumAgePolicyProvider(IOptions<AuthorizationOptions> options)
+    : IAuthorizationPolicyProvider
 {
-    private readonly DefaultAuthorizationPolicyProvider _fallbackPolicyProvider;
+    private readonly DefaultAuthorizationPolicyProvider fallbackPolicyProvider =
+        new(options);
     const string POLICY_PREFIX = "MinimumAge";
-
-    public MinimumAgePolicyProvider(IOptions<AuthorizationOptions> options) =>
-        _fallbackPolicyProvider = new DefaultAuthorizationPolicyProvider(options);
 
     public Task<AuthorizationPolicy?> GetPolicyAsync(string policyName)
     {
-        if (policyName.StartsWith(POLICY_PREFIX, StringComparison.OrdinalIgnoreCase) &&
+        if (policyName.StartsWith(
+                POLICY_PREFIX, StringComparison.OrdinalIgnoreCase) &&
             int.TryParse(policyName.AsSpan(POLICY_PREFIX.Length), out var age) &&
             age >= 0)
         {
@@ -30,7 +30,7 @@ internal class MinimumAgePolicyProvider : IAuthorizationPolicyProvider
     }
 
     public Task<AuthorizationPolicy> GetDefaultPolicyAsync() =>
-        Task.FromResult<AuthorizationPolicy>(
+        Task.FromResult(
             new AuthorizationPolicyBuilder(
                 IdentityConstants.ApplicationScheme)
             .RequireAuthenticatedUser().Build());

--- a/security/authorization/BlazorWebAppAuthorization/Policies/Providers/MinimumAgePolicyProvider.cs
+++ b/security/authorization/BlazorWebAppAuthorization/Policies/Providers/MinimumAgePolicyProvider.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Options;
 
 namespace BlazorWebAppAuthorization.Policies.Providers;
 
-internal class MinimumAgePolicyProvider(IOptions<AuthorizationOptions> options) 
+public class MinimumAgePolicyProvider(IOptions<AuthorizationOptions> options) 
     : IAuthorizationPolicyProvider
 {
     private const string PolicyPrefix = "MinimumAge";

--- a/security/authorization/BlazorWebAppAuthorization/Policies/Providers/MinimumAgePolicyProvider.cs
+++ b/security/authorization/BlazorWebAppAuthorization/Policies/Providers/MinimumAgePolicyProvider.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
 using BlazorWebAppAuthorization.Policies.Requirements;
 
 namespace BlazorWebAppAuthorization.Policies.Providers;
@@ -9,7 +10,7 @@ internal class MinimumAgePolicyProvider : IAuthorizationPolicyProvider
     private readonly DefaultAuthorizationPolicyProvider _fallbackPolicyProvider;
     const string POLICY_PREFIX = "MinimumAge";
 
-    public MinimumAgePolicyProvider(Microsoft.Extensions.Options.IOptions<AuthorizationOptions> options) =>
+    public MinimumAgePolicyProvider(IOptions<AuthorizationOptions> options) =>
         _fallbackPolicyProvider = new DefaultAuthorizationPolicyProvider(options);
 
     public Task<AuthorizationPolicy?> GetPolicyAsync(string policyName)

--- a/security/authorization/BlazorWebAppAuthorization/Policies/Providers/MinimumAgePolicyProvider.cs
+++ b/security/authorization/BlazorWebAppAuthorization/Policies/Providers/MinimumAgePolicyProvider.cs
@@ -10,7 +10,7 @@ public class MinimumAgePolicyProvider(IOptions<AuthorizationOptions> options)
 {
     private const string PolicyPrefix = "MinimumAge";
 
-    private DefaultAuthorizationPolicyProvider FallbackPolicyProvider { get; } = 
+    private DefaultAuthorizationPolicyProvider DefaultPolicyProvider { get; } = 
         new(options);
 
     public Task<AuthorizationPolicy?> GetPolicyAsync(string policyName)
@@ -27,12 +27,12 @@ public class MinimumAgePolicyProvider(IOptions<AuthorizationOptions> options)
             return Task.FromResult<AuthorizationPolicy?>(policy.Build());
         }
 
-        return FallbackPolicyProvider.GetPolicyAsync(policyName);
+        return DefaultPolicyProvider.GetPolicyAsync(policyName);
     }
 
     public Task<AuthorizationPolicy> GetDefaultPolicyAsync() => 
-        FallbackPolicyProvider.GetDefaultPolicyAsync();
+        DefaultPolicyProvider.GetDefaultPolicyAsync();
 
     public Task<AuthorizationPolicy?> GetFallbackPolicyAsync() => 
-        FallbackPolicyProvider.GetFallbackPolicyAsync();
+        DefaultPolicyProvider.GetFallbackPolicyAsync();
 }

--- a/security/authorization/BlazorWebAppAuthorization/Program.cs
+++ b/security/authorization/BlazorWebAppAuthorization/Program.cs
@@ -7,6 +7,7 @@ using BlazorWebAppAuthorization.Components.Account;
 using BlazorWebAppAuthorization.Data;
 using BlazorWebAppAuthorization.Identity;
 using BlazorWebAppAuthorization.Policies.Handlers;
+using BlazorWebAppAuthorization.Policies.Providers;
 using BlazorWebAppAuthorization.Policies.Requirements;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -84,6 +85,7 @@ builder.Services.AddSingleton<IAuthorizationHandler, DocumentAuthorizationHandle
 builder.Services.AddSingleton<IAuthorizationHandler, DocumentAuthorizationCrudHandler>();
 builder.Services.AddSingleton<IAuthorizationHandler, MinimumAgeHandler>();
 builder.Services.AddScoped<IDocumentRepository, DocumentRepository>();
+builder.Services.AddSingleton<IAuthorizationPolicyProvider, MinimumAgePolicyProvider>();
 
 var app = builder.Build();
 

--- a/security/authorization/BlazorWebAppAuthorization/README.md
+++ b/security/authorization/BlazorWebAppAuthorization/README.md
@@ -33,17 +33,17 @@ For more information, see the following resources:
      * A `Department` claim with a `Human Resources` value.
      * The author of a test resource with an `Id` (Guid) of `aaaabbbb-0000-cccc-1111-dddd2222eeee` (Test Document 1).
      * Can perform full CRUD operations on resources in the `AccessDocumentCrud` page.
-     * Satisfies the 'AtLeast21' and 'MinimumAge21' policies, having a `DateOfBirth` claim with a value of `2000-01-01`.
+     * Has a `DateOfBirth` claim with a value of `2000-01-01`, which satisfies the 'AtLeast21' and 'MinimumAge21' policies.
    * `harry@contoso.com` (Password: `Passw0rd!`)
      * The `Admin` role.
      * An `EmployeeNumber` claim with a value of `10`.
      * A `Department` claim with a `Customer Service` value.
      * The author of a test resource with an `Id` (Guid) of `00001111-aaaa-2222-bbbb-3333cccc4444` (Test Document 2).
      * Can create, read, and update resources in the `AccessDocumentCrud` page.
-     * Doesn't satisfy the 'AtLeast21' and 'MinimumAge21' policies, having a `DateOfBirth` claim with a value of `2008-01-01`.
+     * Has a `DateOfBirth` claim with a value of `2008-01-01`, which doesn't satisfy the 'AtLeast21' and 'MinimumAge21' policies.
    * `sarah@contoso.com` (Password: `Passw0rd!`)
      * The `SuperUser` role.
      * Doesn't have claims as an employee (`EmployeeNumber`) or for a department (`Department`).
      * The author of a test resource with an `Id` (Guid) of `11112222-bbbb-3333-cccc-4444dddd5555` (Test Document 3).
      * Can delete and read resources in the `AccessDocumentCrud` page.
-     * Doesn't satisfy the 'AtLeast21' and 'MinimumAge21' policies, having a `DateOfBirth` claim with a value of `2008-01-01`.
+     * Has a `DateOfBirth` claim with a value of `2008-01-01`, which doesn't satisfy the 'AtLeast21' and 'MinimumAge21' policies.

--- a/security/authorization/BlazorWebAppAuthorization/README.md
+++ b/security/authorization/BlazorWebAppAuthorization/README.md
@@ -33,17 +33,17 @@ For more information, see the following resources:
      * A `Department` claim with a `Human Resources` value.
      * The author of a test resource with an `Id` (Guid) of `aaaabbbb-0000-cccc-1111-dddd2222eeee` (Test Document 1).
      * Can perform full CRUD operations on resources in the `AccessDocumentCrud` page.
-     * Satisfies the 'AtLeast21' and 'MinimumAge21' policies with a `DateOfBirth` claim with a value of `2000-01-01`.
+     * Satisfies the 'AtLeast21' and 'MinimumAge21' policies, having a `DateOfBirth` claim with a value of `2000-01-01`.
    * `harry@contoso.com` (Password: `Passw0rd!`)
      * The `Admin` role.
      * An `EmployeeNumber` claim with a value of `10`.
      * A `Department` claim with a `Customer Service` value.
      * The author of a test resource with an `Id` (Guid) of `00001111-aaaa-2222-bbbb-3333cccc4444` (Test Document 2).
      * Can create, read, and update resources in the `AccessDocumentCrud` page.
-     * Doesn't satisfy the 'AtLeast21' and 'MinimumAge21' policies with a `DateOfBirth` claim with a value of `2008-01-01`.
+     * Doesn't satisfy the 'AtLeast21' and 'MinimumAge21' policies, having a `DateOfBirth` claim with a value of `2008-01-01`.
    * `sarah@contoso.com` (Password: `Passw0rd!`)
      * The `SuperUser` role.
      * Doesn't have claims as an employee (`EmployeeNumber`) or for a department (`Department`).
      * The author of a test resource with an `Id` (Guid) of `11112222-bbbb-3333-cccc-4444dddd5555` (Test Document 3).
      * Can delete and read resources in the `AccessDocumentCrud` page.
-     * Doesn't satisfy the 'AtLeast21' and 'MinimumAge21' policies with a `DateOfBirth` claim with a value of `2008-01-01`.
+     * Doesn't satisfy the 'AtLeast21' and 'MinimumAge21' policies, having a `DateOfBirth` claim with a value of `2008-01-01`.

--- a/security/authorization/BlazorWebAppAuthorization/README.md
+++ b/security/authorization/BlazorWebAppAuthorization/README.md
@@ -33,17 +33,17 @@ For more information, see the following resources:
      * A `Department` claim with a `Human Resources` value.
      * The author of a test resource with an `Id` (Guid) of `aaaabbbb-0000-cccc-1111-dddd2222eeee` (Test Document 1).
      * Can perform full CRUD operations on resources in the `AccessDocumentCrud` page.
-     * Satisfies the 'AtLeast21' policy with a `DateOfBirth` claim with a value of `2000-01-01`.
+     * Satisfies the 'AtLeast21' and 'MinimumAge21' policies with a `DateOfBirth` claim with a value of `2000-01-01`.
    * `harry@contoso.com` (Password: `Passw0rd!`)
      * The `Admin` role.
      * An `EmployeeNumber` claim with a value of `10`.
      * A `Department` claim with a `Customer Service` value.
      * The author of a test resource with an `Id` (Guid) of `00001111-aaaa-2222-bbbb-3333cccc4444` (Test Document 2).
      * Can create, read, and update resources in the `AccessDocumentCrud` page.
-     * Doesn't satisfy the 'AtLeast21' policy with a `DateOfBirth` claim with a value of `2008-01-01`.
+     * Doesn't satisfy the 'AtLeast21' and 'MinimumAge21' policies with a `DateOfBirth` claim with a value of `2008-01-01`.
    * `sarah@contoso.com` (Password: `Passw0rd!`)
      * The `SuperUser` role.
      * Doesn't have claims as an employee (`EmployeeNumber`) or for a department (`Department`).
      * The author of a test resource with an `Id` (Guid) of `11112222-bbbb-3333-cccc-4444dddd5555` (Test Document 3).
      * Can delete and read resources in the `AccessDocumentCrud` page.
-     * Doesn't satisfy the 'AtLeast21' policy with a `DateOfBirth` claim with a value of `2008-01-01`.
+     * Doesn't satisfy the 'AtLeast21' and 'MinimumAge21' policies with a `DateOfBirth` claim with a value of `2008-01-01`.


### PR DESCRIPTION
Addresses https://github.com/dotnet/AspNetCore.Docs/issues/37370

Wade, these are the BWA authz sample updates for the custom authz policy provider doc overhaul, which is a WIP at https://github.com/dotnet/AspNetCore.Docs/pull/37379. Let's merge this one first, and then the article PR should build without warnings.