### PR TITLE
BWA authz sample app updates

### DIFF
--- a/security/authorization/BlazorWebAppAuthorization/.gitignore
+++ b/security/authorization/BlazorWebAppAuthorization/.gitignore
@@ -1,1 +1,1 @@
-![Properties/launchSettings.json]
+!/Properties/launchSettings.json

--- a/security/authorization/BlazorWebAppAuthorization/.gitignore
+++ b/security/authorization/BlazorWebAppAuthorization/.gitignore
@@ -1,1 +1,3 @@
-!/Properties/launchSettings.json
+*.json
+!Properties/
+!Properties/launchSettings.json

--- a/security/authorization/BlazorWebAppAuthorization/.gitignore
+++ b/security/authorization/BlazorWebAppAuthorization/.gitignore
@@ -1,3 +1,1 @@
-*.json
-!Properties/
-!Properties/launchSettings.json
+!/Properties/launchSettings.json

--- a/security/authorization/BlazorWebAppAuthorization/Components/Account/Pages/AccessDenied.razor
+++ b/security/authorization/BlazorWebAppAuthorization/Components/Account/Pages/AccessDenied.razor
@@ -1,0 +1,8 @@
+@page "/Account/AccessDenied"
+
+<PageTitle>Access denied</PageTitle>
+
+<header>
+    <h1 class="text-danger">Access denied</h1>
+    <p class="text-danger">You do not have access to this resource.</p>
+</header>

--- a/security/authorization/BlazorWebAppAuthorization/Components/Pages/Home.razor
+++ b/security/authorization/BlazorWebAppAuthorization/Components/Pages/Home.razor
@@ -80,22 +80,11 @@
                 <span class="bi bi-person-fill-nav-menu" aria-hidden="true"></span> Pass 'MinimumAge21' policy
             </NavLink>
         </div>
-        <AuthorizeView Policy="MinimumAge21" Context="minimumAge21Context">
-            <Authorized>
-                <div class="nav-item px-3">
-                    <NavLink class="nav-link" href="pass-minimumage21-policy-with-attribute">
-                        <span class="bi bi-person-fill-nav-menu" aria-hidden="true"></span> Pass 'MinimumAge21' policy (attribute-based)
-                    </NavLink>
-                </div>
-            </Authorized>
-            <NotAuthorized>
-                <p>
-                    You can't see this link to the 'PassMinimumAge21PolicyWithAttribute' component because you don't satisfy 
-                    the 'MinimumAge21' policy. If you navigate to the page at '/pass-minimumage21-policy-with-attribute' in 
-                    the browser's address bar, the Access Denied page is loaded.
-                </p>
-            </NotAuthorized>
-        </AuthorizeView>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="pass-minimumage21-policy-with-attribute">
+                <span class="bi bi-person-fill-nav-menu" aria-hidden="true"></span> Pass 'MinimumAge21' policy (attribute-based)
+            </NavLink>
+        </div>
     </Authorized>
     <NotAuthorized>
         <p>Sign into the app with one of the seeded accounts. See the README file for accounts and credentials.</p>

--- a/security/authorization/BlazorWebAppAuthorization/Program.cs
+++ b/security/authorization/BlazorWebAppAuthorization/Program.cs
@@ -45,6 +45,19 @@ builder.Services.AddIdentityCore<ApplicationUser>()
     .AddEntityFrameworkStores<ApplicationDbContext>();
 */
 
+// Application cookie redirect mapping
+//
+// Anonymous Users: When an unauthenticated user hits a protected endpoint, the cookie handler
+// issues a challenge and redirects to 'LoginPath' with a 'ReturnUrl' parameter.
+//
+// Underage Users: When an authenticated user fails the custom minimum age policy, the handler
+// issues a forbid response and redirects to 'AccessDeniedPath' instead of the login page.
+builder.Services.ConfigureApplicationCookie(options =>
+{
+    options.LoginPath = "/Account/Login";
+    options.AccessDeniedPath = "/Account/AccessDenied";
+});
+
 // Add the AtLeast21 authorization policy
 builder.Services.AddAuthorizationBuilder()
     .AddPolicy("AtLeast21", policy =>

--- a/security/authorization/BlazorWebAppAuthorization/Properties/launchSettings.json
+++ b/security/authorization/BlazorWebAppAuthorization/Properties/launchSettings.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+    "profiles": {
+      "http": {
+        "commandName": "Project",
+        "dotnetRunMessages": true,
+        "launchBrowser": true,
+        "applicationUrl": "http://localhost:5269",
+        "environmentVariables": {
+          "ASPNETCORE_ENVIRONMENT": "Development"
+        }
+      },
+      "https": {
+        "commandName": "Project",
+        "dotnetRunMessages": true,
+        "launchBrowser": true,
+        "applicationUrl": "https://localhost:7247;http://localhost:5269",
+        "environmentVariables": {
+          "ASPNETCORE_ENVIRONMENT": "Development"
+        }
+      }
+    }
+  }

--- a/security/authorization/BlazorWebAppAuthorization/Properties/launchSettings.json
+++ b/security/authorization/BlazorWebAppAuthorization/Properties/launchSettings.json
@@ -1,23 +1,23 @@
 {
   "$schema": "https://json.schemastore.org/launchsettings.json",
-    "profiles": {
-      "http": {
-        "commandName": "Project",
-        "dotnetRunMessages": true,
-        "launchBrowser": true,
-        "applicationUrl": "http://localhost:5269",
-        "environmentVariables": {
-          "ASPNETCORE_ENVIRONMENT": "Development"
-        }
-      },
-      "https": {
-        "commandName": "Project",
-        "dotnetRunMessages": true,
-        "launchBrowser": true,
-        "applicationUrl": "https://localhost:7247;http://localhost:5269",
-        "environmentVariables": {
-          "ASPNETCORE_ENVIRONMENT": "Development"
-        }
+  "profiles": {
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:7247;http://localhost:5269",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:5269",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
       }
     }
   }
+}

--- a/security/authorization/BlazorWebAppAuthorization/README.md
+++ b/security/authorization/BlazorWebAppAuthorization/README.md
@@ -18,7 +18,7 @@ For more information, see the following resources:
 1. If you plan to run the app using the .NET CLI with `dotnet run`, note that the first launch profile in the launch settings file is used to run an app, which is the secure `https` profile (HTTPS protocol). To run the app insecurely (HTTP protocol), take ***either*** of the following approaches:
 
    * Pass the launch profile option to the command when running the app: `dotnet run -lp http`.
-   * In the launch settings file (`Properties/launchSettings.json`), rotate the `http` profile to the top, placing it above the `https` profile.
+   * In the launch settings file (`Properties/launchSettings.json`), rotate the `http` profile to the top, placing it above the `https` profile. Then, the app runs insecurely by default with the `dotnet run` command.
   
    If you use Visual Studio to run the app, Visual Studio automatically uses the `https` launch profile. No action is required to run the app securely when using Visual Studio.
 

--- a/security/authorization/BlazorWebAppAuthorization/README.md
+++ b/security/authorization/BlazorWebAppAuthorization/README.md
@@ -15,10 +15,10 @@ For more information, see the following resources:
 
 1. Clone this repository or download a ZIP archive of the repository. For more information, see [How to download a sample](https://learn.microsoft.com/aspnet/core/introduction-to-aspnet-core#how-to-download-a-sample).
 
-1. If you plan to run the app using the .NET CLI with `dotnet run`, note that the first launch profile in the launch settings file is used to run an app, which is the insecure `http` profile (HTTP protocol). To run the app securely (HTTPS protocol), take ***either*** of the following approaches:
+1. If you plan to run the app using the .NET CLI with `dotnet run`, note that the first launch profile in the launch settings file is used to run an app, which is the secure `https` profile (HTTPS protocol). To run the app insecurely (HTTP protocol), take ***either*** of the following approaches:
 
-   * Pass the launch profile option to the command when running the app: `dotnet run -lp https`.
-   * In the launch settings file (`Properties/launchSettings.json`), rotate the `https` profile to the top, placing it above the `http` profile.
+   * Pass the launch profile option to the command when running the app: `dotnet run -lp http`.
+   * In the launch settings file (`Properties/launchSettings.json`), rotate the `http` profile to the top, placing it above the `https` profile.
   
    If you use Visual Studio to run the app, Visual Studio automatically uses the `https` launch profile. No action is required to run the app securely when using Visual Studio.
 

--- a/security/authorization/BlazorWebAppAuthorization/README.md
+++ b/security/authorization/BlazorWebAppAuthorization/README.md
@@ -15,7 +15,7 @@ For more information, see the following resources:
 
 1. Clone this repository or download a ZIP archive of the repository. For more information, see [How to download a sample](https://learn.microsoft.com/aspnet/core/introduction-to-aspnet-core#how-to-download-a-sample).
 
-1. If you plan to run the app using the .NET CLI with `dotnet run`, note that the first launch profile in the launch settings file is used to run an app, which is the secure `https` profile (HTTPS protocol). To run the app insecurely (HTTP protocol), take ***either*** of the following approaches:
+1. If you plan to run the app using the .NET CLI with `dotnet run`, note that the first launch profile in the launch settings file is used to run the app, which is the secure `https` profile (HTTPS protocol). If you specifically need to run the app insecurely (HTTP protocol), take ***either*** of the following approaches:
 
    * Pass the launch profile option to the command when running the app: `dotnet run -lp http`.
    * In the launch settings file (`Properties/launchSettings.json`), rotate the `http` profile to the top, placing it above the `https` profile. Then, the app runs insecurely by default with the `dotnet run` command.


### PR DESCRIPTION
Addresses https://github.com/dotnet/AspNetCore.Docs/pull/37379

Here are the updates to the BWA authz sample in response to Stephen's review feedfack ...

* The `launchSettings.json` file wasn't included due to a bad `.gitignore` file. 😈 It isn't a problem for anyone loading the project first in VS because VS automatically generates one. It's needed for devs running the app using the .NET CLI: If the app starts in the Production environment because the file isn't there, the seed data code doesn't run. I'm also going ahead and rotating the HTTPS profile to the top of the file for HTTPS by default. The README is updated to match the new default behavior.
* Adding an `AccessDenied` page.
* Changing the `Home` component to show the link to the attribute-based custom policy provider link because ......
* Cookie redirect mapping is being added, which will handle both anonymous users (login page) and underage users (access denied page). I tested the updates, and they work. 🎉 